### PR TITLE
docs: fix cask name in the brewfile section

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Also, if you keep a _[Brewfile](https://github.com/Homebrew/homebrew-bundle#usag
 ```rb
 repo = "lencx/chatgpt"
 tap repo, "https://github.com/#{repo}.git"
-cask "popcorn-time", args: { "no-quarantine": true }
+cask "chatgpt", args: { "no-quarantine": true }
 ```
 
 ## 📢 Announcement


### PR DESCRIPTION
Hello,

This PR fixes the cask name in the `brewfile` section. I noticed that this had been causing some confusion for users, so I hope this helps to clear things up.

I also wanted to express my gratitude to you as the maintainer for all of your hard work on this project. Your efforts are greatly appreciated and make a big difference for everyone who uses ChatGPT.

Thank you again for all that you do, and I hope you find this PR to be useful.
