### PR TITLE
fix(build): mac m1 chip copy/paste

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -45,4 +45,4 @@ custom-protocol = [ "tauri/custom-protocol" ]
 [profile.release]
 strip = true
 lto = true
-opt-level = "z"
+opt-level = "s"


### PR DESCRIPTION
Hi guy! This pr fixes the bug that the mac m1 chip computer cannot use the paste shortcut key