### PR TITLE
🐞 fix(src-tauri/src/app/menu.rs): fix warning on linux

### DIFF
--- a/src-tauri/src/app/menu.rs
+++ b/src-tauri/src/app/menu.rs
@@ -29,6 +29,7 @@ pub fn init() -> Menu {
 
     let stay_on_top =
         CustomMenuItem::new("stay_on_top".to_string(), "Stay On Top").accelerator("CmdOrCtrl+T");
+    #[cfg(target_os = "macos")]
     let titlebar =
         CustomMenuItem::new("titlebar".to_string(), "Titlebar").accelerator("CmdOrCtrl+B");
     let theme_light = CustomMenuItem::new("theme_light".to_string(), "Light");
@@ -40,6 +41,7 @@ pub fn init() -> Menu {
     } else {
         stay_on_top
     };
+    #[cfg(target_os = "macos")]
     let titlebar_menu = if chat_conf.titlebar {
         titlebar.selected()
     } else {


### PR DESCRIPTION
add `#[cfg(target_os = "macos")]` when declare titlebar and titlebar_menu