### PR TITLE
make AppImage the default Linux installation file

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 **Latest:**
 
 - `Mac`: [ChatGPT_0.7.4_x64.dmg](https://github.com/lencx/ChatGPT/releases/download/v0.7.4/ChatGPT_0.7.4_x64.dmg)
-- `Linux`: [chat-gpt_0.7.4_amd64.deb](https://github.com/lencx/ChatGPT/releases/download/v0.7.4/chat-gpt_0.7.4_amd64.deb)
+- `Linux`: [chat-gpt_0.7.4_amd64.AppImage](https://github.com/lencx/ChatGPT/releases/download/v0.7.4/chat-gpt_0.7.4_amd64.AppImage)
 - `Windows`: [ChatGPT_0.7.4_x64_en-US.msi](https://github.com/lencx/ChatGPT/releases/download/v0.7.4/ChatGPT_0.7.4_x64_en-US.msi)
 
 [Other version...](https://github.com/lencx/ChatGPT/releases)


### PR DESCRIPTION
Almost all Linux distributions can run AppImage file,however, only those Linux distributions which has  `dpkg` command can install a deb file.BTW, AppImage contains all the dependencies and library files that app needs while running,which can avoid many local library link errors.