### PR TITLE
Update chatgpt.rb to version 0.10.3

### DIFF
--- a/casks/chatgpt.rb
+++ b/casks/chatgpt.rb
@@ -1,6 +1,6 @@
 cask "chatgpt" do
-   version "0.6.10"
-   sha256 "e85062565f826d32219c53b184d6df9c89441d4231cdfff775c2de8c50ac9906"
+   version "0.10.3"
+   sha256 "f44838a80844999191a303684fd7ae1811dd2fae6709aebe8bff23c70f9b8a10"
 
   url "https://github.com/lencx/ChatGPT/releases/download/v#{version}/ChatGPT_#{version}_x64.dmg"
   name "ChatGPT"


### PR DESCRIPTION
checked locally:
```shell
brew reinstall --cask chatgpt --no-quarantine
==> Downloading https://github.com/lencx/ChatGPT/releases/download/v0.10.3/ChatGPT_0.10.3_x64.dmg 
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/575340621/b 
######################################################################## 100.0% 
Warning: Cannot verify integrity of 'a77703907b8af9fcb951d9e896b73c3424f60799b39b49a6b9a2d2e3fca259e3--ChatGPT_0.10.3_x64.dmg'. 
No checksum was provided for this cask.
For your reference, the checksum is:
  sha256 "f44838a80844999191a303684fd7ae1811dd2fae6709aebe8bff23c70f9b8a10"
==> Uninstalling Cask chatgpt
==> Backing App 'ChatGPT.app' up to '/usr/local/Caskroom/chatgpt/0.6.10/ChatGPT.app' 
==> Removing App '/Applications/ChatGPT.app'
==> Purging files for version 0.6.10 of Cask chatgpt 
==> Installing Cask chatgpt
Warning: macOS's Gatekeeper has been disabled for this Cask 
==> Moving App 'ChatGPT.app' to '/Applications/ChatGPT.app' 
🍺  chatgpt was successfully installed!
```