### PR TITLE
Fix Chinese input method "Enter" 

### DIFF
--- a/src-tauri/src/scripts/core.js
+++ b/src-tauri/src/scripts/core.js
@@ -101,6 +101,11 @@ async function init() {
     }
   });
 
+  // Fix Chinese input method "Enter" on Safari
+  document.addEventListener("keydown",(e)=>{
+    if(e.keyCode==229) e.stopPropagation();
+  }, true)
+
   if (window.location.host === 'chat.openai.com') {
     window.__sync_prompts = async function() {
       await invoke('sync_prompts', { time: Date.now() });

--- a/src-tauri/src/scripts/core.js
+++ b/src-tauri/src/scripts/core.js
@@ -102,8 +102,8 @@ async function init() {
   });
 
   // Fix Chinese input method "Enter" on Safari
-  document.addEventListener("keydown",(e)=>{
-    if(e.keyCode==229) e.stopPropagation();
+  document.addEventListener("keydown", (e) => {
+    if(e.keyCode == 229) e.stopPropagation();
   }, true)
 
   if (window.location.host === 'chat.openai.com') {


### PR DESCRIPTION
Fix #369 

ChatGPT 官方前端正确处理了中文输入法的问题，对 keydown 的 event.isComposing==true 进行了判断，输入法状态下按 Enter 不会发送消息。

但是因为在 MacOS 上 Tauri 默认使用的是 Safari 内核，而 Safari 的 event.isComposing 始终为 false，只有通过 keyCode 来判断是否为输入法状态。

因此只要全局阻止 e.keyCode==229 event 传递就可以了