### PR TITLE
feat: automatically update the release version installed by homebrew

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,6 +151,13 @@ jobs:
           generate_release_notes: false
           files: ./artifacts/**/*
 
+      - name: Update Homebrew Version
+        run: |
+          bash updateBrewVersion.sh
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Update ChatGPT release version for Homebrew
+
   updater:
     runs-on: ubuntu-latest
     needs: release-chatgpt

--- a/updateBrewVersion.sh
+++ b/updateBrewVersion.sh
@@ -1,0 +1,16 @@
+###
+ # @Author: Vincent Young
+ # @Date: 2023-02-17 19:34:47
+ # @LastEditors: Vincent Young
+ # @LastEditTime: 2023-02-17 19:37:11
+ # @FilePath: /ChatGPT/updateBrewVersion.sh
+ # @Telegram: https://t.me/missuo
+ # 
+ # Copyright © 2023 by Vincent, All Rights Reserved. 
+### 
+
+update_chatgpt(){
+    last_version=$(curl -Ls "https://api.github.com/repos/lencx/ChatGPT/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | sed 's/v//g')
+    sed -i "s/version.*/version \"${last_version}\"/g" casks/chatgpt.rb
+}
+update_chatgpt


### PR DESCRIPTION
When a new version is released, you have to modify `casks/chatgpt.rb` manually. 

This pr does the job of automatically updating the version.