### PR TITLE
fix: node version campatible issue

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -74,5 +74,8 @@
     "typescript": "^4.9.4",
     "vite": "^4.0.0",
     "vite-tsconfig-paths": "^4.0.2"
+  },
+  "engines": {
+    "node": "^14.18.0 || ^16.0.0"
   }
 }


### PR DESCRIPTION
[issue](https://github.com/lencx/ChatGPT/issues/463)

If the user has incompatible Nodejs version, `pnpm install` will throw an error and prevent installing packages. For example:

```bash
$ sudo n node/15.14.0
   installed : v15.14.0 (with npm 7.7.6)

$ pnpm install 
 ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)

Your Node version is incompatible with "/Users/dulin/workspace/github.com/mrdulin/ChatGPT".

Expected version: ^14.18.0 || ^16.0.0
Got: v15.14.0

This is happening because the package's manifest has an engines.node field specified.
To fix this issue, install the required Node version.
```