### PR TITLE
feat: when exporting as markdown, have the current date in the file name

### DIFF
--- a/src-tauri/src/scripts/export.js
+++ b/src-tauri/src/scripts/export.js
@@ -154,7 +154,7 @@ async function init() {
     }).join('');
     const data = ExportMD.turndown(content);
     const { id, filename } = getName();
-    await invoke('save_file', { name: `notes/${id}.md`, content: data });
+    await invoke('save_file', { name: `notes/${new Date().toISOString().slice(0, 10)}-${id}.md`, content: data });
     await invoke('download_list', { pathname: 'chat.notes.json', filename, id, dir: 'notes' });
   }
 


### PR DESCRIPTION
This will enable having an organized view when viewing the files in file explorer/or in any text editor (vscode for example)