### PR TITLE
Generate markup file path based on chat title

### DIFF
--- a/scripts/export.js
+++ b/scripts/export.js
@@ -164,8 +164,12 @@ async function exportInit() {
       .join('');
     const data = ExportMD.turndown(content);
     const { id, filename } = getName();
-    await invoke('save_file', { name: `notes/${id}.md`, content: data });
-    await invoke('download_list', { pathname: 'chat.notes.json', filename, id, dir: 'notes' });
+    const sanitizedText = filename.replace(/[<>:\"\/\?\'\\*\.#]/g, '');
+    const withoutSpaces = sanitizedText.replace(/ /g, '_');
+    const parts = withoutSpaces.split('|');
+    const filePath = `notes/${parts.join('/')}.md`;
+    await invoke('save_file', { name: filePath, content: data });
+    await invoke('download_list', { pathname: 'chat.notes.json', withoutSpaces, id, dir: 'notes' });
   }
 
   async function downloadThread({ as = Format.PNG } = {}) {
@@ -310,7 +314,7 @@ async function exportInit() {
   function getName() {
     const id = window.crypto.getRandomValues(new Uint32Array(1))[0].toString(36);
     const name =
-      document.querySelector('nav .overflow-y-auto a.hover\\:bg-gray-800')?.innerText?.trim() || '';
+      document.querySelector('title')?.innerText?.trim() || '';
     return { filename: name ? name : id, id, pathname: 'chat.download.json' };
   }
 }


### PR DESCRIPTION
Instead of using IDs on file names which PR changes logic in way that title are used.

It also allows user to put those files to subfolder by using chat names which contains **|**
e.g. chat title `Work|Go|Hello World` would be stored to file `notes/Work/Go/Hello_World.md`

And because file name is not random ID anymore you can also update those markdown files by exporting again (as long you don't rename chat between).


PS. Because it looks to be unclear if this tool will still get updates now when author is focusing to [NoFWL](https://github.com/lencx/nofwl) I did publish my customized version with this change included on https://github.com/olljanat/ChatGPT