### PR TITLE
Fix URL check preventing script load when using GPT-4

### DIFF
--- a/src-tauri/src/app/setup.rs
+++ b/src-tauri/src/app/setup.rs
@@ -87,7 +87,7 @@ pub fn init(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {
           .hidden_title(true);
       }
 
-      if url == "https://chat.openai.com" {
+      if url.starts_with("https://chat.openai.com") {
         main_win = main_win
           .initialization_script(include_str!("../vendors/floating-ui-core.js"))
           .initialization_script(include_str!("../vendors/floating-ui-dom.js"))


### PR DESCRIPTION
There are multiple valid ChatGPT URLs, including
- https://chat.openai.com
- https://chat.openai.com/?model=gpt-4
- https://chat.openai.com/?model=gpt-4-browsing

This fixes a bug where only the first URL in the above list would be considered valid, preventing proper initialisation with the other URLs.

The bug can be reproduced by setting this flag in `chat.conf.json`:
```
"main_origin": "https://chat.openai.com/?model=gpt-4",
```