### PR TITLE
Fixed system tray icon not disappearing on exit

### DIFF
--- a/src-tauri/src/app/menu.rs
+++ b/src-tauri/src/app/menu.rs
@@ -484,7 +484,7 @@ pub fn tray_handler(handle: &AppHandle, event: SystemTrayEvent) {
           }
         };
       }
-      "quit" => std::process::exit(0),
+      "quit" => app.exit(0),
       _ => (),
     },
     _ => (),

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -9,6 +9,7 @@ mod utils;
 
 use app::{cmd, fs_extra, gpt, menu, script, setup, window};
 use conf::AppConf;
+use tauri::Manager;
 use tauri_plugin_autostart::MacosLauncher;
 use tauri_plugin_log::{
   fern::colors::{Color, ColoredLevelConfig},
@@ -99,6 +100,7 @@ async fn main() {
     .on_system_tray_event(menu::tray_handler)
     .on_window_event(move |event| {
       if let tauri::WindowEvent::CloseRequested { api, .. } = event.event() {
+        let app_handle = event.window().app_handle().clone();
         let win = event.window().clone();
         let app_conf = AppConf::read();
         if win.label() == "core" {
@@ -112,14 +114,14 @@ async fn main() {
                   .amend(serde_json::json!({ "isinit" : false, "main_close": is_ok }))
                   .write();
                 if is_ok {
-                  std::process::exit(0);
+                  app_handle.exit(0);
                 } else {
                   win.minimize().unwrap();
                 }
               },
             );
           } else if app_conf.main_close {
-            std::process::exit(0);
+            app_handle.exit(0);
           } else {
             win.minimize().unwrap();
           }

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -98,6 +98,7 @@ pub fn clear_conf(app: &tauri::AppHandle) {
     Note: The application will exit automatically after the configuration cleanup!",
     root.to_string_lossy()
   );
+  let app_clone = app.clone();
   tauri::api::dialog::ask(
     app.get_window("core").as_ref(),
     "Clear Config",
@@ -105,7 +106,7 @@ pub fn clear_conf(app: &tauri::AppHandle) {
     move |is_ok| {
       if is_ok {
         fs::remove_dir_all(root).unwrap();
-        std::process::exit(0);
+        app_clone.exit(0);
       }
     },
   );


### PR DESCRIPTION
Replaced `std::process::exit(0)` with `tauri::AppHandle::exit()` across multiple files to ensure proper cleanup, including removal of the system tray icon upon exit