### PR TITLE
Updating USER_INPUT_SELECTOR for scripts/export.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ node_modules/
 .pnp.*
 
 # Testing
-private/
+*private*/
 
 # rust
 target/

--- a/scripts/export.js
+++ b/scripts/export.js
@@ -157,7 +157,7 @@ async function exportInit() {
   }
 
   const SELECTOR = 'main div.group';
-  const USER_INPUT_SELECTOR = 'div.empty\\:hidden';
+  const USER_INPUT_SELECTOR = 'div.relative.flex.w-\\[calc\\(100\\%-50px\\)\\].flex-col.gizmo\\:w-full.lg\\:w-\\[calc\\(100\\%-115px\\)\\].gizmo\\:text-gizmo-gray-600.gizmo\\:dark\\:text-gray-300';
 
   function processNode(node, replaceInUserInput = false) {
     let j = node.cloneNode(true);

--- a/scripts/markdown.export.js
+++ b/scripts/markdown.export.js
@@ -11,6 +11,7 @@ var ExportMD = (function () {
   const turndownService = new TurndownService({
     hr: '---',
   })
+    .keep([`\\`])
     .use(gfm)
     .addRule('code', {
       filter(node) {


### PR DESCRIPTION
As of 2023.10.23 the export function isn't working because OpenAI changed the formatting for the user div class. This is a small edit to USER_INPUT_SELECTOR to bring it up-to-date.

https://github.com/djdarcy/DJChatGPT/commit/1738a42ac966cda1d574db51d8326fc7704a1aa8#diff-07730f255965d05b06fd534bacae2f4821dac223b364e725b8df6c53ad16503a

The [scripts/markdown.export.js](https://github.com/djdarcy/DJChatGPT/commit/1738a42ac966cda1d574db51d8326fc7704a1aa8#diff-d8287d10ad40a5d40508e503a90cee874f37a5881dcc769faab837950f43bf05) change isn't wholly necessary (just a personal tweak for my own purposes).